### PR TITLE
Add Windows build to GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,10 +55,15 @@ jobs:
 
     - name: Build and run tests
       run: |
-        gn gen out
-        autoninja -C out hello
+        gnargs=""
         ext=""
-        [ "$RUNNER_OS" = "Windows" ] && ext=".exe"
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          # Use the runner's MSVC (cl.exe) instead of fetching a clang package.
+          gnargs='--args=mini_chromium_is_clang=false'
+          ext=".exe"
+        fi
+        gn gen out $gnargs
+        autoninja -C out hello
         "./out/hello$ext"
         autoninja -C out hello_unittest
         "./out/hello_unittest$ext"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,9 +23,9 @@ jobs:
       DEPOT_TOOLS_WIN_TOOLCHAIN: 0
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.10'
 
@@ -33,7 +33,7 @@ jobs:
       run: |
         pip install setuptools
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: |
           .cipd/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      DEPOT_TOOLS_WIN_TOOLCHAIN: 0
 
     steps:
     - uses: actions/checkout@v4
@@ -39,7 +46,7 @@ jobs:
 
     - name: Set up PATH
       run: |
-        echo "`pwd`/depot_tools" >> $GITHUB_PATH
+        echo "${{ github.workspace }}/depot_tools" >> "$GITHUB_PATH"
 
     - name: Sync
       run: |
@@ -50,7 +57,8 @@ jobs:
       run: |
         gn gen out
         autoninja -C out hello
-        ./out/hello
+        ext=""
+        [ "$RUNNER_OS" = "Windows" ] && ext=".exe"
+        "./out/hello$ext"
         autoninja -C out hello_unittest
-        ./out/hello_unittest
-
+        "./out/hello_unittest$ext"

--- a/DEPS
+++ b/DEPS
@@ -41,6 +41,17 @@ deps = {
     'condition': 'host_os == "linux"',
   },
 
+  'buildtools/win': {
+    'packages': [
+      {
+        'package': 'gn/gn/windows-amd64',
+        'version': Var('gn_version'),
+      }
+    ],
+    'dep_type': 'cipd',
+    'condition': 'host_os == "win"',
+  },
+
   'third_party/googletest/src':
       Var('chromium_git') + '/external/github.com/google/googletest.git@' +
           '4fe3307fb2d9f86d19777c7eb0e4809e9694dde7',

--- a/build/BUILDCONFIG.gn
+++ b/build/BUILDCONFIG.gn
@@ -14,8 +14,13 @@ if (current_cpu == "") {
   current_cpu = target_cpu
 }
 
-set_default_toolchain(
-    "//third_party/mini_chromium/src/build/config:gcc_like_toolchain")
+if (current_os == "win") {
+  set_default_toolchain(
+      "//third_party/mini_chromium/src/build/config:msvc_toolchain_$current_cpu")
+} else {
+  set_default_toolchain(
+      "//third_party/mini_chromium/src/build/config:gcc_like_toolchain")
+}
 
 declare_args() {
   is_debug = true


### PR DESCRIPTION
## Summary
Add `windows-latest` to the CI matrix and make the Windows build actually
pass, rebased onto the latest `main` (2026-06 DEPS update).

## Changes
- **DEPS**: add `buildtools/win` (gn `windows-amd64` CIPD, `host_os == "win"`).
  ninja is already `${platform}`-based, so it covers Windows automatically.
- **build/BUILDCONFIG.gn**: select the toolchain by OS — `msvc_toolchain_$current_cpu`
  on Windows, `gcc_like_toolchain` elsewhere (crashpad's pattern). The old code
  forced `gcc_like_toolchain` everywhere, so `clang++` was handed MSVC-style flags
  (`/W4`, `/Zi`, `/std:c++23preview`) and failed.
- **.github/workflows/main.yml**:
  - matrix: add `windows-latest` (`fail-fast: false` keeps mac/linux independent).
  - run all jobs under `shell: bash` (Git Bash on Windows) — one set of steps.
  - `DEPOT_TOOLS_WIN_TOOLCHAIN=0` + `mini_chromium_is_clang=false` on Windows so the
    build uses the runner's Visual Studio `cl.exe` and skips the large clang download.
  - handle the `.exe` suffix when running the binaries.
  - bump actions to Node 24 majors (checkout@v5, setup-python@v6, cache@v5) to clear
    the "Node.js 20 is deprecated" warning.

## Verification (GitHub Actions)
All three matrix jobs pass:
- ubuntu-latest ✅
- macOS-latest ✅
- windows-latest ✅ — `LINK hello.exe` → `Hello, world 1`, `[ PASSED ] 2 tests.`

No Node.js 20 deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)