### PR TITLE
[DEPS] Update to 2026-06 pins (mini_chromium / googletest / gn / buildtools)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: actions/setup-python@v5
       with:
@@ -26,7 +26,7 @@ jobs:
       run: |
         pip install setuptools
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           .cipd/

--- a/.gn
+++ b/.gn
@@ -1,2 +1,6 @@
 # The location of the build configuration file.
 buildconfig = "//build/BUILDCONFIG.gn"
+
+# mini_chromium runs Python build scripts (e.g. find_mac_sdk.py) via
+# exec_script; macOS only ships python3, so point GN at it explicitly.
+script_executable = "python3"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A C++ project template built on Chromium's toolchain — `mini_chromium` (Chromium's low-level `base` routines), GN + Ninja for builds, and googletest for unit tests. The sample target is a trivial `hello` program; the value of this repo is the wiring (GN config, DEPS, CI), not the code. New projects clone this and replace the `hello`/`hello_static` targets.
+
+## Prerequisites
+
+Builds require `depot_tools` on PATH (provides `gclient`, `gn`, `autoninja`):
+
+```bash
+git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+export PATH=$PWD/depot_tools:$PATH
+```
+
+## Common commands
+
+```bash
+# Fetch all dependencies declared in DEPS (googletest, mini_chromium, gn, ninja, buildtools).
+# Run this first, and again after editing DEPS.
+gclient sync
+
+# Generate the Ninja build files for an output directory.
+gn gen out/Debug
+
+# Build and run the main executable.
+autoninja -C out/Debug hello
+./out/Debug/hello
+
+# Build and run the full unit test suite.
+autoninja -C out/Debug hello_unittest
+./out/Debug/hello_unittest
+
+# Run a single test case (googletest filter).
+./out/Debug/hello_unittest --gtest_filter=SampleTest.TestGetStaticText
+```
+
+There is no separate lint step; formatting follows `.clang-format` (`BasedOnStyle: Chromium`), and `clang-format` is supplied via CIPD.
+
+## Architecture
+
+- **`.gn`** points GN at **`build/BUILDCONFIG.gn`**, which sets the default toolchain to mini_chromium's `gcc_like_toolchain` and applies mini_chromium's default configs to every target type (`executable`, `static_library`, `test`, etc.). The build is debug by default (`is_debug = true`).
+- **`build/test.gni`** defines the `test()` template used in `BUILD.gn`. It is just an `executable` with `testonly = true` — there is no test runner framework beyond googletest's own `main`.
+- **`BUILD.gn`** (root) declares the targets. The pattern is: business logic lives in a `static_library` (`hello_static`), the `executable` (`hello`) and the `test` (`hello_unittest`) both depend on it. Test targets add `include_dirs = [ "src" ]` and depend on `//third_party/googletest:gtest`.
+- **`DEPS`** pins exact revisions of mini_chromium, googletest, buildtools, and CIPD versions of `gn` and `ninja`. Dependency changes happen here, not via a package manager. `gclient sync` materializes them into `third_party/` and `buildtools/`.
+
+## Adding code
+
+1. Add sources under `src/` and (for shared logic) declare them in a `static_library` in `BUILD.gn`.
+2. Have the `executable` depend on that library via `deps`.
+3. Add tests under `test/`, declared with the `test()` template, depending on the library and `//third_party/googletest:gtest`.
+
+## CI
+
+`.github/workflows/main.yml` runs on push/PR to `main` across `ubuntu-latest` and `macOS-latest`. It clones `depot_tools`, runs `gclient sync`, then builds and runs both `hello` and `hello_unittest`. CI builds into `out/` (no `Debug` suffix) — the output directory name is arbitrary. DEPS-fetched dirs are cached against `hashFiles('DEPS')`.

--- a/DEPS
+++ b/DEPS
@@ -2,7 +2,7 @@ vars = {
   'chromium_git': 'https://chromium.googlesource.com',
 
   # GN CIPD package version.
-  'gn_version': 'git_revision:feafd1012a32c05ec6095f69ddc3850afb621f3a',
+  'gn_version': 'git_revision:197d7a5fa261d011bb9db414031caeeb907ccfd1',
 
   # ninja CIPD package version.
   # https://chrome-infra-packages.appspot.com/p/infra/3pp/tools/ninja
@@ -17,7 +17,7 @@ allowed_hosts = [
 deps = {
   'buildtools':
       Var('chromium_git') + '/chromium/src/buildtools.git@' +
-          '9fba2b959007f7ef80990be4e940d98a692f7dd0',
+          '0d39be5a3f129cf1f35e7812108a2184e2193315',
 
   'buildtools/mac': {
     'packages': [
@@ -43,11 +43,11 @@ deps = {
 
   'third_party/googletest/src':
       Var('chromium_git') + '/external/github.com/google/googletest.git@' +
-          '011959aafddcd30611003de96cfd8d7a7685c700',
+          '4fe3307fb2d9f86d19777c7eb0e4809e9694dde7',
 
   'third_party/mini_chromium/src':
       Var('chromium_git') + '/chromium/mini_chromium@' +
-          'c081fd005b09a59a505b09a4b506f8ba45f70859',
+          'e5169551c51f3a52eee36b3b03f219cefe380237',
 
   'third_party/ninja': {
     'packages': [

--- a/third_party/googletest/BUILD.gn
+++ b/third_party/googletest/BUILD.gn
@@ -14,7 +14,9 @@ config("gtest_public_config") {
 static_library("gtest") {
   testonly = true
   sources = [
+    "src/googletest/include/gtest/gtest-assertion-result.h",
     "src/googletest/include/gtest/gtest-death-test.h",
+    "src/googletest/include/gtest/gtest-matchers.h",
     "src/googletest/include/gtest/gtest-message.h",
     "src/googletest/include/gtest/gtest-param-test.h",
     "src/googletest/include/gtest/gtest-printers.h",
@@ -30,18 +32,17 @@ static_library("gtest") {
     "src/googletest/include/gtest/internal/gtest-death-test-internal.h",
     "src/googletest/include/gtest/internal/gtest-filepath.h",
     "src/googletest/include/gtest/internal/gtest-internal.h",
-    "src/googletest/include/gtest/internal/gtest-linked_ptr.h",
-    "src/googletest/include/gtest/internal/gtest-param-util-generated.h",
     "src/googletest/include/gtest/internal/gtest-param-util.h",
     "src/googletest/include/gtest/internal/gtest-port-arch.h",
     "src/googletest/include/gtest/internal/gtest-port.h",
     "src/googletest/include/gtest/internal/gtest-string.h",
-    "src/googletest/include/gtest/internal/gtest-tuple.h",
     "src/googletest/include/gtest/internal/gtest-type-util.h",
     "src/googletest/src/gtest-all.cc",
+    "src/googletest/src/gtest-assertion-result.cc",
     "src/googletest/src/gtest-death-test.cc",
     "src/googletest/src/gtest-filepath.cc",
     "src/googletest/src/gtest-internal-inl.h",
+    "src/googletest/src/gtest-matchers.cc",
     "src/googletest/src/gtest-port.cc",
     "src/googletest/src/gtest-printers.cc",
     "src/googletest/src/gtest-test-part.cc",
@@ -64,146 +65,6 @@ static_library("gtest_main") {
   ]
   deps = [
     ":gtest",
-  ]
-}
-
-test("gtest_all_test") {
-  sources = [
-    "src/googletest/test/googletest-death-test-test.cc",
-    "src/googletest/test/googletest-filepath-test.cc",
-    "src/googletest/test/googletest-message-test.cc",
-    "src/googletest/test/googletest-options-test.cc",
-    "src/googletest/test/googletest-port-test.cc",
-    "src/googletest/test/googletest-printers-test.cc",
-    "src/googletest/test/googletest-test-part-test.cc",
-    "src/googletest/test/gtest-typed-test2_test.cc",
-    "src/googletest/test/gtest-typed-test_test.cc",
-    "src/googletest/test/gtest-typed-test_test.h",
-    "src/googletest/test/gtest_main_unittest.cc",
-    "src/googletest/test/gtest_pred_impl_unittest.cc",
-    "src/googletest/test/gtest_prod_test.cc",
-    "src/googletest/test/gtest_unittest.cc",
-    "src/googletest/test/production.cc",
-    "src/googletest/test/production.h",
-  ]
-  configs -= [ "//third_party/mini_chromium/src/build/config:Wexit_time_destructors" ]
-  configs += [ ":gtest_private_config" ]
-  deps = [
-    ":gtest",
-    ":gtest_main",
-  ]
-}
-
-test("gtest_environment_test") {
-  sources = [
-    "src/googletest/test/gtest_environment_test.cc",
-  ]
-  configs += [ ":gtest_private_config" ]
-  deps = [
-    ":gtest",
-  ]
-}
-
-test("gtest_listener_test") {
-  sources = [
-    "src/googletest/test/googletest-listener-test.cc",
-  ]
-  deps = [
-    ":gtest",
-  ]
-}
-
-test("gtest_no_test") {
-  sources = [
-    "src/googletest/test/gtest_no_test_unittest.cc",
-  ]
-  deps = [
-    ":gtest",
-  ]
-}
-
-test("gtest_param_test") {
-  sources = [
-    "src/googletest/test/googletest-param-test-test.cc",
-    "src/googletest/test/googletest-param-test-test.h",
-    "src/googletest/test/googletest-param-test2-test.cc",
-  ]
-  configs -= [ "//third_party/mini_chromium/src/build/config:Wexit_time_destructors" ]
-  configs += [ ":gtest_private_config" ]
-  deps = [
-    ":gtest",
-  ]
-
-  if (mini_chromium_is_clang) {
-    cflags_cc = [
-      # For src/googlemock/test/gmock-matchers_test.cc’s
-      # Unstreamable::value_.
-      "-Wno-unused-private-field",
-    ]
-  }
-}
-
-test("gtest_premature_exit_test") {
-  sources = [
-    "src/googletest/test/gtest_premature_exit_test.cc",
-  ]
-  deps = [
-    ":gtest",
-  ]
-}
-
-test("gtest_repeat_test") {
-  sources = [
-    "src/googletest/test/gtest_repeat_test.cc",
-  ]
-  configs += [ ":gtest_private_config" ]
-  deps = [
-    ":gtest",
-  ]
-}
-
-test("gtest_sole_header_test") {
-  sources = [
-    "src/googletest/test/gtest_sole_header_test.cc",
-  ]
-  deps = [
-    ":gtest",
-    ":gtest_main",
-  ]
-}
-
-test("gtest_stress_test") {
-  sources = [
-    "src/googletest/test/gtest_stress_test.cc",
-  ]
-  configs += [ ":gtest_private_config" ]
-  deps = [
-    ":gtest",
-  ]
-}
-
-test("gtest_unittest_api_test") {
-  sources = [
-    "src/googletest/test/gtest-unittest-api_test.cc",
-  ]
-  deps = [
-    ":gtest",
-  ]
-}
-
-group("gtest_all_tests") {
-  testonly = true
-  deps = [
-    ":gtest_all_test",
-    ":gtest_environment_test",
-    ":gtest_listener_test",
-    ":gtest_no_test",
-    ":gtest_param_test",
-    ":gtest_premature_exit_test",
-    ":gtest_repeat_test",
-    ":gtest_sole_header_test",
-    ":gtest_stress_test",
-    ":gtest_unittest_api_test",
   ]
 }
 
@@ -232,21 +93,19 @@ static_library("gmock") {
   sources = [
     "src/googlemock/include/gmock/gmock-actions.h",
     "src/googlemock/include/gmock/gmock-cardinalities.h",
-    "src/googlemock/include/gmock/gmock-generated-actions.h",
-    "src/googlemock/include/gmock/gmock-generated-function-mockers.h",
-    "src/googlemock/include/gmock/gmock-generated-matchers.h",
-    "src/googlemock/include/gmock/gmock-generated-nice-strict.h",
+    "src/googlemock/include/gmock/gmock-function-mocker.h",
     "src/googlemock/include/gmock/gmock-matchers.h",
     "src/googlemock/include/gmock/gmock-more-actions.h",
     "src/googlemock/include/gmock/gmock-more-matchers.h",
+    "src/googlemock/include/gmock/gmock-nice-strict.h",
     "src/googlemock/include/gmock/gmock-spec-builders.h",
     "src/googlemock/include/gmock/gmock.h",
     "src/googlemock/include/gmock/internal/custom/gmock-generated-actions.h",
     "src/googlemock/include/gmock/internal/custom/gmock-matchers.h",
     "src/googlemock/include/gmock/internal/custom/gmock-port.h",
-    "src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h",
     "src/googlemock/include/gmock/internal/gmock-internal-utils.h",
     "src/googlemock/include/gmock/internal/gmock-port.h",
+    "src/googlemock/include/gmock/internal/gmock-pp.h",
     "src/googlemock/src/gmock-all.cc",
     "src/googlemock/src/gmock-cardinalities.cc",
     "src/googlemock/src/gmock-internal-utils.cc",
@@ -273,75 +132,5 @@ static_library("gmock_main") {
   deps = [
     ":gmock",
     ":gtest",
-  ]
-}
-
-test("gmock_all_test") {
-  sources = [
-    "src/googlemock/test/gmock-actions_test.cc",
-    "src/googlemock/test/gmock-cardinalities_test.cc",
-    "src/googlemock/test/gmock-generated-actions_test.cc",
-    "src/googlemock/test/gmock-generated-function-mockers_test.cc",
-    "src/googlemock/test/gmock-generated-internal-utils_test.cc",
-    "src/googlemock/test/gmock-generated-matchers_test.cc",
-    "src/googlemock/test/gmock-internal-utils_test.cc",
-    "src/googlemock/test/gmock-matchers_test.cc",
-    "src/googlemock/test/gmock-more-actions_test.cc",
-    "src/googlemock/test/gmock-nice-strict_test.cc",
-    "src/googlemock/test/gmock-port_test.cc",
-    "src/googlemock/test/gmock-spec-builders_test.cc",
-    "src/googlemock/test/gmock_test.cc",
-  ]
-  configs += [
-    ":gmock_private_config",
-    ":gtest_private_config",
-  ]
-  deps = [
-    ":gmock",
-    ":gmock_main",
-    ":gtest",
-  ]
-
-  if (mini_chromium_is_clang) {
-    cflags_cc = [
-      # For src/googlemock/test/gmock-matchers_test.cc’s
-      # testing::gmock_matchers_test::Unprintable::c_.
-      "-Wno-unused-private-field",
-    ]
-  }
-}
-
-test("gmock_link_test") {
-  sources = [
-    "src/googlemock/test/gmock_link2_test.cc",
-    "src/googlemock/test/gmock_link_test.cc",
-    "src/googlemock/test/gmock_link_test.h",
-  ]
-  configs += [ ":gmock_private_config" ]
-  deps = [
-    ":gmock",
-    ":gmock_main",
-    ":gtest",
-  ]
-}
-
-test("gmock_stress_test") {
-  sources = [
-    "src/googlemock/test/gmock_stress_test.cc",
-  ]
-  configs -= [ "//third_party/mini_chromium/src/build/config:Wexit_time_destructors" ]
-  configs += [ ":gmock_private_config" ]
-  deps = [
-    ":gmock",
-    ":gtest",
-  ]
-}
-
-group("gmock_all_tests") {
-  testonly = true
-  deps = [
-    ":gmock_all_test",
-    ":gmock_link_test",
-    ":gmock_stress_test",
   ]
 }


### PR DESCRIPTION
## Summary
Update dependency pins to match chromium/src (`d0c5cd51`, 2026-06-12),
using mini_chromium's main HEAD.

| Dependency | Old | New |
|---|---|---|
| mini_chromium | `c081fd00` | `e5169551` |
| googletest | `011959aa` | `4fe3307f` |
| gn | `feafd101` | `197d7a5f` |
| buildtools | `9fba2b95` | `0d39be5a` |
| ninja | `1.12.1.chromium.4` | unchanged |

## Changes
- **DEPS**: bump the four pins above.
- **.gn**: add `script_executable = "python3"` — new mini_chromium runs
  `find_mac_sdk.py` via `exec_script`, and macOS only ships `python3`.
- **third_party/googletest/BUILD.gn**: refresh gtest/gmock source lists for
  the new googletest layout (drop removed `gtest-linked_ptr.h` /
  `gtest-tuple.h` / `gtest-param-util-generated.h` / `gmock-generated-*`;
  add `gtest-assertion-result` / `gtest-matchers` / `gmock-function-mocker`
  / `gmock-pp`). Drop googletest's own self-test targets, unused by this
  template.
- **.github/workflows/main.yml**: bump `checkout`/`cache` actions to v4.
- **CLAUDE.md**: add Claude Code guidance.

## Verification (local, clean build)
- `gn gen out/Debug` ✅
- `./out/Debug/hello` → `Hello, world 1` ✅
- `./out/Debug/hello_unittest` → `[ PASSED ] 2 tests.` ✅
- `gmock` library builds ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)